### PR TITLE
Remove a bunch of deprecation warnings

### DIFF
--- a/src/main/kotlin/net/starlegacy/StarLegacy.kt
+++ b/src/main/kotlin/net/starlegacy/StarLegacy.kt
@@ -440,17 +440,17 @@ class StarLegacy : JavaPlugin() {
 			}
 
 			registerContext(CachedStar::class.java) { c: BukkitCommandExecutionContext ->
-				Space.starNameCache[c.popFirstArg().toUpperCase()].orNull()
+				Space.starNameCache[c.popFirstArg().uppercase()].orNull()
 					?: throw InvalidCommandArgument("No such star")
 			}
 
 			registerContext(CachedPlanet::class.java) { c: BukkitCommandExecutionContext ->
-				Space.planetNameCache[c.popFirstArg().toUpperCase()].orNull()
+				Space.planetNameCache[c.popFirstArg().uppercase()].orNull()
 					?: throw InvalidCommandArgument("No such planet")
 			}
 
 			registerContext(CargoCrate::class.java) { c: BukkitCommandExecutionContext ->
-				CargoCrates[c.popFirstArg().toUpperCase()]
+				CargoCrates[c.popFirstArg().uppercase()]
 					?: throw InvalidCommandArgument("No such crate")
 			}
 

--- a/src/main/kotlin/net/starlegacy/cache/nations/SettlementCache.kt
+++ b/src/main/kotlin/net/starlegacy/cache/nations/SettlementCache.kt
@@ -50,7 +50,7 @@ object SettlementCache : ManualCache() {
 			val tax = settlement.tradeTax
 			val data = SettlementData(id, territory, name, leader, nation, cityState, minBuild, tax)
 			SETTLEMENT_DATA[id] = data
-			nameCache[data.name.toLowerCase()] = id
+			nameCache[data.name.lowercase()] = id
 		}
 
 		for (settlement in Settlement.all()) {
@@ -74,9 +74,9 @@ object SettlementCache : ManualCache() {
 				}
 
 				change[Settlement::name]?.let {
-					nameCache.remove(data.name.toLowerCase())
+					nameCache.remove(data.name.lowercase())
 					data.name = it.string()
-					nameCache[data.name.toLowerCase()] = id
+					nameCache[data.name.lowercase()] = id
 				}
 
 				change[Settlement::leader]?.let {
@@ -114,9 +114,9 @@ object SettlementCache : ManualCache() {
 			synced {
 				val id: Oid<Settlement> = change.oid
 
-				val name = get(id).name.toLowerCase() // get the name first since it's about to be removed
+				val name = get(id).name.lowercase() // get the name first since it's about to be removed
 				SETTLEMENT_DATA.remove(id)
-				nameCache.remove(name.toLowerCase())
+				nameCache.remove(name.lowercase())
 			}
 		}
 	}
@@ -138,5 +138,5 @@ object SettlementCache : ManualCache() {
 	operator fun get(settlementId: Oid<Settlement>): SettlementData = SETTLEMENT_DATA[settlementId]
 		?: error("$settlementId is not cached")
 
-	fun getByName(name: String): Oid<Settlement>? = nameCache[name.toLowerCase()]
+	fun getByName(name: String): Oid<Settlement>? = nameCache[name.lowercase()]
 }

--- a/src/main/kotlin/net/starlegacy/cache/trade/CargoCrates.kt
+++ b/src/main/kotlin/net/starlegacy/cache/trade/CargoCrates.kt
@@ -42,7 +42,7 @@ object CargoCrates : ManualCache() {
 		}.toMap()
 
 		NAME_MAP = crates.map {
-			it.name.toUpperCase() to it
+			it.name.uppercase() to it
 		}.toMap()
 
 		ID_MAP = crates.map {
@@ -124,7 +124,7 @@ object CargoCrates : ManualCache() {
 
 	operator fun get(box: ShulkerBox): CargoCrate? = ITEM_MAP[box.type to box.customName]
 
-	operator fun get(name: String?): CargoCrate? = NAME_MAP[name?.toUpperCase()]
+	operator fun get(name: String?): CargoCrate? = NAME_MAP[name?.uppercase()]
 
 	operator fun get(id: Oid<CargoCrate>): CargoCrate = ID_MAP[id] ?: error("Crate $id not cached!")
 	//endregion CACHES

--- a/src/main/kotlin/net/starlegacy/command/misc/DyeCommand.kt
+++ b/src/main/kotlin/net/starlegacy/command/misc/DyeCommand.kt
@@ -17,7 +17,7 @@ import org.bukkit.inventory.ItemStack
 object DyeCommand : SLCommand() {
 	@Default()
 	fun execute(sender: Player, newColor: String) {
-		val newDyeColor = enumValueOfOrNull<DyeColor>(newColor.toUpperCase())
+		val newDyeColor = enumValueOfOrNull<DyeColor>(newColor.uppercase())
 			?: fail { "Valid colors are " + DyeColor.values().joinToString() }
 
 		val item = sender.inventory.itemInMainHand
@@ -40,7 +40,7 @@ object DyeCommand : SLCommand() {
 	@Subcommand("inventory|inv|all")
 	@CommandPermission("starlegacy.dyeinventoy")
 	fun executeInv(sender: Player, newColor: String) {
-		val newDyeColor = enumValueOfOrNull<DyeColor>(newColor.toUpperCase())
+		val newDyeColor = enumValueOfOrNull<DyeColor>(newColor.uppercase())
 			?: fail { "Valid colors are " + DyeColor.values().joinToString() }
 
 		for (item: ItemStack? in sender.inventory) {

--- a/src/main/kotlin/net/starlegacy/command/misc/ShuttleCommand.kt
+++ b/src/main/kotlin/net/starlegacy/command/misc/ShuttleCommand.kt
@@ -25,7 +25,7 @@ object ShuttleCommand : SLCommand() {
 	private val worldEditPlugin: WorldEditPlugin get() = JavaPlugin.getPlugin(WorldEditPlugin::class.java)
 
 	private fun validateName(name: String) {
-		failIf(name != name.toLowerCase()) { "Name must be lowercase" }
+		failIf(name != name.lowercase()) { "Name must be lowercase" }
 		failIf(!name.replace("_", "").isAlphanumeric()) { "Name must use only letters, numbers, and underscores" }
 	}
 

--- a/src/main/kotlin/net/starlegacy/command/nations/settlementZones/SettlementZoneCommand.kt
+++ b/src/main/kotlin/net/starlegacy/command/nations/settlementZones/SettlementZoneCommand.kt
@@ -167,7 +167,7 @@ internal object SettlementZoneCommand : SLCommand() {
 	}
 
 	private fun validateName(name: String) {
-		failIf(name != name.toLowerCase())
+		failIf(name != name.lowercase())
 		{ "Name must be lowercase" }
 
 		failIf(name.length !in 3..50)

--- a/src/main/kotlin/net/starlegacy/command/progression/AdvanceAdminCommand.kt
+++ b/src/main/kotlin/net/starlegacy/command/progression/AdvanceAdminCommand.kt
@@ -169,7 +169,7 @@ object AdvanceAdminCommand : SLCommand() {
 		}
 
 		sender msg "&aThat player would be refunded $refund XP, enough to get to level $level with $remaining XP remaining."
-		sender msg "&7&oThey were a level ${data.level} ${data.track.name.toLowerCase()}, with ${data.points} points."
+		sender msg "&7&oThey were a level ${data.level} ${data.track.name.lowercase()}, with ${data.points} points."
 	}
 
 	@Subcommand("giverefund")

--- a/src/main/kotlin/net/starlegacy/command/starship/BlueprintCommand.kt
+++ b/src/main/kotlin/net/starlegacy/command/starship/BlueprintCommand.kt
@@ -36,7 +36,7 @@ object BlueprintCommand : SLCommand() {
 	}
 
 	private fun validateName(name: String) {
-		failIf(name != name.toLowerCase()) {
+		failIf(name != name.lowercase()) {
 			"Name must be lowercase"
 		}
 		failIf(name.length !in 2..50) {

--- a/src/main/kotlin/net/starlegacy/command/starship/MiscStarshipCommands.kt
+++ b/src/main/kotlin/net/starlegacy/command/starship/MiscStarshipCommands.kt
@@ -68,7 +68,7 @@ object MiscStarshipCommands : SLCommand() {
 	fun onLoadShip(sender: Player, player: String, world: String) = asyncCommand(sender) {
 		val uuid = resolveOfflinePlayer(player)
 		redis {
-			val key = "starships.lastpiloted.$uuid.${world.toLowerCase()}"
+			val key = "starships.lastpiloted.$uuid.${world.lowercase()}"
 
 			failIf(!exists(key)) { "$player doesn't have a ship saved for /loadship in $world" }
 
@@ -178,7 +178,7 @@ object MiscStarshipCommands : SLCommand() {
 	@CommandAlias("settarget|starget|st")
 	fun onSetTarget(sender: Player, set: String, @Optional player: OnlinePlayer?) {
 		val starship = getStarshipRiding(sender)
-		val weaponSet = set.toLowerCase()
+		val weaponSet = set.lowercase()
 		failIf(!starship.weaponSets.containsKey(weaponSet)) {
 			"No such weapon set $weaponSet"
 		}

--- a/src/main/kotlin/net/starlegacy/database/schema/economy/CargoCrate.kt
+++ b/src/main/kotlin/net/starlegacy/database/schema/economy/CargoCrate.kt
@@ -54,5 +54,5 @@ data class CargoCrate(
 		BLACK(SLTextStyle.BLACK, Material.BLACK_SHULKER_BOX),
 	}
 
-	fun getValue(planet: String): Double = values.getOrDefault(planet.toUpperCase(), 0.0)
+	fun getValue(planet: String): Double = values.getOrDefault(planet.uppercase(), 0.0)
 }

--- a/src/main/kotlin/net/starlegacy/feature/chat/ChannelSelections.kt
+++ b/src/main/kotlin/net/starlegacy/feature/chat/ChannelSelections.kt
@@ -51,7 +51,7 @@ object ChannelSelections : SLComponent() {
 
 			val message: String = event.message
 			val args: List<String> = message.removePrefix("/").split(" ")
-			val command: String = args[0].toLowerCase()
+			val command: String = args[0].lowercase()
 
 			ChatChannel.values().firstOrNull { it.commandAliases.contains(command) }?.let { channel ->
 				event.isCancelled = true
@@ -71,12 +71,12 @@ object ChannelSelections : SLComponent() {
 				}
 
 				if (oldChannel == channel) {
-					player action "&cYou're already in chat ${channel.displayName.toUpperCase()}&c! " +
+					player action "&cYou're already in chat ${channel.displayName.uppercase()}&c! " +
 							"&o(Hint: To get back to global, use /global)"
 					return@listen
 				} else {
 					localCache[playerID] = channel
-					val info: String = "&f&lSwitched to &l${channel.displayName.toUpperCase()}&f&l chat! " +
+					val info: String = "&f&lSwitched to &l${channel.displayName.uppercase()}&f&l chat! " +
 							"To switch back to your previous chat, use '/${oldChannel.commandAliases.first()}'"
 					player action info
 				}

--- a/src/main/kotlin/net/starlegacy/feature/economy/cargotrade/ShipmentGenerator.kt
+++ b/src/main/kotlin/net/starlegacy/feature/economy/cargotrade/ShipmentGenerator.kt
@@ -83,7 +83,7 @@ object ShipmentGenerator : SLComponent() {
 				val importingPlanets: Set<String> = crate.values.filterValues { it < 0 }.keys
 
 				val importingCities: List<TradeCityData> = TradeCities.getAll().filter {
-					importingPlanets.contains(Regions.get<RegionTerritory>(it.territoryId).world.toUpperCase())
+					importingPlanets.contains(Regions.get<RegionTerritory>(it.territoryId).world.uppercase())
 				}.toList()
 
 				return@associate crate to importingCities

--- a/src/main/kotlin/net/starlegacy/feature/economy/cargotrade/ShipmentManager.kt
+++ b/src/main/kotlin/net/starlegacy/feature/economy/cargotrade/ShipmentManager.kt
@@ -136,7 +136,7 @@ object ShipmentManager : SLComponent() {
 	private fun MenuHelper.getPlanetItem(shipment: UnclaimedShipment): GuiItem {
 		val destinationTerritory: RegionTerritory = Regions[shipment.to.territoryId]
 		val destinationWorld = destinationTerritory.world
-		val planetId = destinationWorld.toLowerCase().replace(" ", "")
+		val planetId = destinationWorld.lowercase().replace(" ", "")
 		val planetIcon = CustomItems["planet_icon_$planetId"] ?: CustomItems.DETONATOR
 		return guiButton(planetIcon.itemStack(1))
 	}

--- a/src/main/kotlin/net/starlegacy/feature/gas/collectionfactors/CollectionFactor.java
+++ b/src/main/kotlin/net/starlegacy/feature/gas/collectionfactors/CollectionFactor.java
@@ -16,7 +16,7 @@ public abstract class CollectionFactor {
 
     private static CollectionFactor valueOf(String text) {
         String[] params = text.split(":");
-        switch (params[0].toLowerCase()) {
+        switch (params[0].lowercase()) {
             case "atmosphereheight":
                 return new AtmosphereHeightFactor(Integer.parseInt(params[1]), Integer.parseInt(params[2]));
             case "distance":

--- a/src/main/kotlin/net/starlegacy/feature/gear/blaster/Blasters.kt
+++ b/src/main/kotlin/net/starlegacy/feature/gear/blaster/Blasters.kt
@@ -32,7 +32,7 @@ object Blasters {
 	}
 
 	fun getColor(player: Player): Color {
-		if (player.world.name.toLowerCase().contains("arena")) {
+		if (player.world.name.lowercase().contains("arena")) {
 			return getRandomColor(player.uniqueId)
 		}
 
@@ -55,7 +55,7 @@ object Blasters {
 				return
 			}
 
-			if (!entity.getWorld().name.toLowerCase().contains("arena")) {
+			if (!entity.getWorld().name.lowercase().contains("arena")) {
 				removePower(blaster, powerUsage)
 			}
 

--- a/src/main/kotlin/net/starlegacy/feature/gear/powerarmor/PowerArmorManager.kt
+++ b/src/main/kotlin/net/starlegacy/feature/gear/powerarmor/PowerArmorManager.kt
@@ -46,7 +46,7 @@ object PowerArmorManager {
 								PotionEffect(PotionEffectType.SPEED, 20, 2)
 							)
 
-							if (hasMovedInLastSecond(player) && !player.world.name.toLowerCase().contains("arena")) {
+							if (hasMovedInLastSecond(player) && !player.world.name.lowercase().contains("arena")) {
 								removePower(item, 1)
 							}
 						}
@@ -56,7 +56,7 @@ object PowerArmorManager {
 							)
 						}
 						PowerArmorModule.ROCKET_BOOSTING -> {
-							if (player.isGliding && !player.world.name.toLowerCase().contains("arena")) {
+							if (player.isGliding && !player.world.name.lowercase().contains("arena")) {
 								removePower(item, 5)
 							}
 						}
@@ -91,7 +91,7 @@ object PowerArmorManager {
 					player.velocity = player.velocity.midpoint(player.location.direction.multiply(0.6))
 					player.world.spawnParticle(Particle.SMOKE_NORMAL, player.location, 5)
 
-					if (!player.world.name.toLowerCase().contains("arena")) {
+					if (!player.world.name.lowercase().contains("arena")) {
 						removePower(item, 5)
 					}
 

--- a/src/main/kotlin/net/starlegacy/feature/gear/powerarmor/PowerArmorModule.kt
+++ b/src/main/kotlin/net/starlegacy/feature/gear/powerarmor/PowerArmorModule.kt
@@ -29,7 +29,7 @@ enum class PowerArmorModule(
 		}
 
 		operator fun get(name: String?): PowerArmorModule? {
-			return nameMap[name?.toUpperCase()]
+			return nameMap[name?.uppercase()]
 		}
 	}
 }

--- a/src/main/kotlin/net/starlegacy/feature/misc/PlanetSpawns.kt
+++ b/src/main/kotlin/net/starlegacy/feature/misc/PlanetSpawns.kt
@@ -35,7 +35,7 @@ object PlanetSpawns : SLComponent() {
 		Tasks.async {
 			val planets = LinkedList(Space.getPlanets())
 			planets.removeAll {
-				!File(PLUGIN.sharedDataFolder, "planet_spawn_descriptions/${it.name.toLowerCase()}").exists()
+				!File(PLUGIN.sharedDataFolder, "planet_spawn_descriptions/${it.name.lowercase()}").exists()
 			}
 
 			// check how many active players live on each planet
@@ -68,7 +68,7 @@ object PlanetSpawns : SLComponent() {
 			}
 
 			val extraLores: Map<CachedPlanet, List<String>> = orderedPlanets.associateWith { planet ->
-				val file = File(PLUGIN.sharedDataFolder, "planet_spawn_descriptions/${planet.name.toLowerCase()}")
+				val file = File(PLUGIN.sharedDataFolder, "planet_spawn_descriptions/${planet.name.lowercase()}")
 
 				if (!file.exists()) {
 					file.createNewFile()
@@ -89,7 +89,7 @@ object PlanetSpawns : SLComponent() {
 					val pane = outlinePane(x = 0, y = 0, length = 9, height = rows)
 
 					for (planet in orderedPlanets) {
-						val nameLower: String = planet.name.toLowerCase()
+						val nameLower: String = planet.name.lowercase()
 						val planetIcon = (CustomItems["planet_icon_$nameLower"] ?: CustomItems.DETONATOR).itemStack(1)
 
 						val planetName: String = planet.name

--- a/src/main/kotlin/net/starlegacy/feature/misc/customblocks.kt
+++ b/src/main/kotlin/net/starlegacy/feature/misc/customblocks.kt
@@ -31,8 +31,8 @@ open class CustomBlock(
 		}
 		val customItem = CustomItems[itemUsed]
 
-		val isTool = customItem == null && itemUsed.type.name.toLowerCase().contains(tool)
-		val isSpecialItem = customItem != null && customItem.id.toLowerCase().replace("drill", "pickaxe").contains(tool)
+		val isTool = customItem == null && itemUsed.type.name.lowercase().contains(tool)
+		val isSpecialItem = customItem != null && customItem.id.lowercase().replace("drill", "pickaxe").contains(tool)
 
 		return if (isTool || isSpecialItem) cloneDrops() else arrayOf()
 	}

--- a/src/main/kotlin/net/starlegacy/feature/misc/customitems.kt
+++ b/src/main/kotlin/net/starlegacy/feature/misc/customitems.kt
@@ -303,7 +303,7 @@ object CustomItems {
 
 	//region Planet Icons
 	private fun registerPlanetIcon(name: String, model: Int): CustomItem = makeItem(
-		id = "planet_icon_${name.toLowerCase().replace(" ", "")}",
+		id = "planet_icon_${name.lowercase().replace(" ", "")}",
 		name = name,
 		mat = APPLE,
 		model = model

--- a/src/main/kotlin/net/starlegacy/feature/progression/advancement/Advancements.kt
+++ b/src/main/kotlin/net/starlegacy/feature/progression/advancement/Advancements.kt
@@ -134,7 +134,7 @@ object Advancements : SLComponent() {
 	private fun fetchAdvancements(playerId: UUID) {
 		val advancements: Set<SLAdvancement> = SLPlayer[playerId.slPlayerId]
 			?.unlockedAdvancements
-			?.map { SLAdvancement.valueOf(it.toUpperCase()) }
+			?.map { SLAdvancement.valueOf(it.uppercase()) }
 			?.toSet()
 			?: setOf()
 

--- a/src/main/kotlin/net/starlegacy/feature/progression/advancement/SLAdvancement.kt
+++ b/src/main/kotlin/net/starlegacy/feature/progression/advancement/SLAdvancement.kt
@@ -36,7 +36,7 @@ enum class SLAdvancementCategory(
 		background = "block/black_concrete"
 	);
 
-	val advancementKey = name.toLowerCase()
+	val advancementKey = name.lowercase()
 
 	val namespacedKey = PLUGIN.namespacedKey(advancementKey)
 }
@@ -580,7 +580,7 @@ enum class SLAdvancement(
 	);
 	//endregion
 
-	val advancementKey = name.toLowerCase()
+	val advancementKey = name.lowercase()
 
 	val namespacedKey = PLUGIN.namespacedKey(advancementKey)
 

--- a/src/main/kotlin/net/starlegacy/feature/space/CachedPlanet.kt
+++ b/src/main/kotlin/net/starlegacy/feature/space/CachedPlanet.kt
@@ -55,7 +55,7 @@ class CachedPlanet(
 	var orbitDistance: Int = orbitDistance; private set
 	var orbitProgress: Double = orbitProgress; private set
 
-	val planetIcon: CustomItem = CustomItems["planet_icon_${name.toLowerCase().replace(" ", "")}"]
+	val planetIcon: CustomItem = CustomItems["planet_icon_${name.lowercase().replace(" ", "")}"]
 		?: CustomItems.DETONATOR
 
 	init {

--- a/src/main/kotlin/net/starlegacy/feature/space/NamedCelestialBody.kt
+++ b/src/main/kotlin/net/starlegacy/feature/space/NamedCelestialBody.kt
@@ -3,5 +3,5 @@ package net.starlegacy.feature.space
 interface NamedCelestialBody {
 	val name: String
 
-	val id get() = name.toLowerCase().replace(" ", "")
+	val id get() = name.lowercase().replace(" ", "")
 }

--- a/src/main/kotlin/net/starlegacy/feature/starship/PilotedStarships.kt
+++ b/src/main/kotlin/net/starlegacy/feature/starship/PilotedStarships.kt
@@ -89,7 +89,7 @@ object PilotedStarships : SLComponent() {
 	private fun saveLoadshipData(starship: ActivePlayerStarship, player: Player) {
 		val schematic = StarshipSchematic.createSchematic(starship)
 
-		val key = "starships.lastpiloted.${player.uniqueId}.${starship.world.name.toLowerCase()}"
+		val key = "starships.lastpiloted.${player.uniqueId}.${starship.world.name.lowercase()}"
 
 		Tasks.async {
 			redis {
@@ -249,6 +249,6 @@ object PilotedStarships : SLComponent() {
 	}
 
 	private fun getDisplayName(data: PlayerStarshipData): String {
-		return data.name ?: data.type.displayName.toLowerCase()
+		return data.name ?: data.type.displayName.lowercase()
 	}
 }

--- a/src/main/kotlin/net/starlegacy/feature/starship/StarshipType.kt
+++ b/src/main/kotlin/net/starlegacy/feature/starship/StarshipType.kt
@@ -312,13 +312,13 @@ enum class StarshipType(
 
 	companion object {
 		private val stringMap = mutableMapOf<String, StarshipType>().apply {
-			putAll(values().associateBy { it.name.toLowerCase() })
-			putAll(values().associateBy { it.displayName.toLowerCase() })
+			putAll(values().associateBy { it.name.lowercase() })
+			putAll(values().associateBy { it.displayName.lowercase() })
 
 			println(this)
 		}
 
-		fun getType(name: String): StarshipType? = stringMap[name.toLowerCase()]
+		fun getType(name: String): StarshipType? = stringMap[name.lowercase()]
 
 		fun getUnlockedTypes(player: Player): List<StarshipType> = values()
 			.filter { it.canUse(player) }

--- a/src/main/kotlin/net/starlegacy/feature/starship/active/SubsystemDetector.kt
+++ b/src/main/kotlin/net/starlegacy/feature/starship/active/SubsystemDetector.kt
@@ -71,7 +71,7 @@ object SubsystemDetector {
 	private fun detectSign(starship: ActivePlayerStarship, block: Block) {
 		val sign = block.state as Sign
 
-		if (sign.type.isWallSign && sign.getLine(0).toLowerCase().contains("node")) {
+		if (sign.type.isWallSign && sign.getLine(0).lowercase().contains("node")) {
 			val inwardFace = sign.getFacing().oppositeFace
 			val location = sign.block.getRelative(inwardFace).location
 			val pos = Vec3i(location)
@@ -82,7 +82,7 @@ object SubsystemDetector {
 			for (weaponSubsystem in weaponSubsystems) {
 				val nodes = sign.lines.slice(1..3)
 					.filter { it.isNotEmpty() }
-					.map { it.toLowerCase() }
+					.map { it.lowercase() }
 				for (node in nodes) {
 					starship.weaponSets[node].add(weaponSubsystem)
 				}

--- a/src/main/kotlin/net/starlegacy/feature/starship/control/StarshipSigns.kt
+++ b/src/main/kotlin/net/starlegacy/feature/starship/control/StarshipSigns.kt
@@ -34,7 +34,7 @@ enum class StarshipSigns(val undetectedText: String, val baseLines: Array<String
 		override fun onClick(player: Player, sign: Sign, rightClick: Boolean) {
 			val starship = findPlayerStarship(player) ?: return
 			val lines = sign.lines
-			val set = lines[1].toLowerCase()
+			val set = lines[1].lowercase()
 
 			if (!starship.weaponSets.containsKey(set)) {
 				player msg "&cNo nodes for $set"

--- a/src/main/kotlin/net/starlegacy/feature/starship/factory/StarshipFactories.kt
+++ b/src/main/kotlin/net/starlegacy/feature/starship/factory/StarshipFactories.kt
@@ -170,7 +170,7 @@ object StarshipFactories : SLComponent() {
 			list.add("&c$item&8: &d$count")
 		}
 
-		return list.joinToString("&e, ").toLowerCase()
+		return list.joinToString("&e, ").lowercase()
 	}
 
 	fun getRequiredAmount(data: BlockData): Int {

--- a/src/main/kotlin/net/starlegacy/listener/gear/BlasterListener.kt
+++ b/src/main/kotlin/net/starlegacy/listener/gear/BlasterListener.kt
@@ -101,7 +101,7 @@ object BlasterListener : SLEventListener() {
 		if (event.entityType != EntityType.SKELETON) return
 		val skeleton = event.entity as Skeleton
 
-		if (skeleton.world.name.toLowerCase().contains("arena")) Tasks.sync {
+		if (skeleton.world.name.lowercase().contains("arena")) Tasks.sync {
 			val blasterRifle = CustomItems["blaster_rifle"]?.itemStack(1)
 			val meta = blasterRifle?.itemMeta
 			meta?.lore = listOf("PINK")

--- a/src/main/kotlin/net/starlegacy/listener/gear/DetonatorListener.kt
+++ b/src/main/kotlin/net/starlegacy/listener/gear/DetonatorListener.kt
@@ -89,7 +89,7 @@ object DetonatorListener : SLEventListener() {
 				player.world.createExplosion(detonator, 1f, false, false)
 				player.world.playSound(detonator.location, Sound.ENTITY_GENERIC_EXPLODE, 10f, 0.5f)
 
-				if (!blockExplodeEvent.callEvent() && !detonator.world.name.toLowerCase().contains("arena")) {
+				if (!blockExplodeEvent.callEvent() && !detonator.world.name.lowercase().contains("arena")) {
 					return@syncDelay
 				}
 

--- a/src/main/kotlin/net/starlegacy/listener/gear/PowerArmorListener.kt
+++ b/src/main/kotlin/net/starlegacy/listener/gear/PowerArmorListener.kt
@@ -87,7 +87,7 @@ object PowerArmorListener : SLEventListener() {
 			}
 
 			if (cause == EntityDamageEvent.DamageCause.ENTITY_ATTACK
-				&& !player.world.name.toLowerCase().contains("arena")
+				&& !player.world.name.lowercase().contains("arena")
 			) {
 				removePower(item, 100)
 			}
@@ -103,7 +103,7 @@ object PowerArmorListener : SLEventListener() {
 						|| cause == EntityDamageEvent.DamageCause.ENTITY_EXPLOSION)
 			) {
 				modifier = 0.0
-				if (!player.world.name.toLowerCase().contains("arena")) {
+				if (!player.world.name.lowercase().contains("arena")) {
 					removePower(moduleItem, 10)
 				}
 			}

--- a/src/main/kotlin/net/starlegacy/listener/gear/SwordListener.kt
+++ b/src/main/kotlin/net/starlegacy/listener/gear/SwordListener.kt
@@ -87,7 +87,7 @@ object SwordListener : SLEventListener() {
 	fun onZombieSpawn(event: CreatureSpawnEvent) {
 		if (event.entityType != EntityType.ZOMBIE) return
 		val zombie = event.entity as Zombie
-		if (zombie.world.name.toLowerCase().contains("arena")) Tasks.sync {
+		if (zombie.world.name.lowercase().contains("arena")) Tasks.sync {
 			zombie.equipment?.setItemInMainHand(CustomItems["energy_sword_purple"]?.itemStack(1))
 		}
 	}
@@ -97,7 +97,7 @@ object SwordListener : SLEventListener() {
 		if (event.entityType != EntityType.VINDICATOR) return
 		val vindicator = event.entity as Vindicator
 
-		if (vindicator.world.name.toLowerCase().contains("arena")) Tasks.sync {
+		if (vindicator.world.name.lowercase().contains("arena")) Tasks.sync {
 			vindicator.equipment?.setItemInMainHand(CustomItems["energy_sword_green"]?.itemStack(1))
 		}
 	}
@@ -107,7 +107,7 @@ object SwordListener : SLEventListener() {
 		if (event.entityType != EntityType.VEX) return
 		val vex = event.entity as Vex
 
-		if (vex.world.name.toLowerCase().contains("arena")) Tasks.sync {
+		if (vex.world.name.lowercase().contains("arena")) Tasks.sync {
 			vex.equipment?.setItemInMainHand(CustomItems["energy_sword_blue"]?.itemStack(1))
 		}
 	}
@@ -117,7 +117,7 @@ object SwordListener : SLEventListener() {
 		if (event.entityType != EntityType.WITHER_SKELETON) return
 		val witherskeleton = event.entity as WitherSkeleton
 
-		if (witherskeleton.world.name.toLowerCase().contains("arena")) Tasks.sync {
+		if (witherskeleton.world.name.lowercase().contains("arena")) Tasks.sync {
 			witherskeleton.equipment?.setItemInMainHand(CustomItems["energy_sword_red"]?.itemStack(1))
 		}
 	}

--- a/src/main/kotlin/net/starlegacy/updater/Updater.kt
+++ b/src/main/kotlin/net/starlegacy/updater/Updater.kt
@@ -320,7 +320,7 @@ object Updater : SLComponent() {
 		names: MutableSet<String>
 	) {
 		DataInputStream(FileInputStream(file)).use { input ->
-			var name = input.readUTF().toLowerCase()
+			var name = input.readUTF().lowercase()
 
 			val size = input.readInt()
 
@@ -441,7 +441,7 @@ object Updater : SLComponent() {
 					Gson().fromJson(it, LegacyCryoData::class.java)
 				}
 				val player = UUID.fromString(child.nameWithoutExtension)
-				val world = legacy.world.toLowerCase()
+				val world = legacy.world.lowercase()
 				val pos = Vec3i(legacy.x, legacy.y, legacy.z)
 				CryoPods.setCryoPod(player, world, pos)
 			} catch (e: Exception) {
@@ -487,7 +487,7 @@ object Updater : SLComponent() {
 		}
 	}
 
-	private fun getStarshipType(originalType: String): StarshipType? = when (originalType.toLowerCase()) {
+	private fun getStarshipType(originalType: String): StarshipType? = when (originalType.lowercase()) {
 		"star fighter", "star_fighter" -> StarshipType.STARFIGHTER
 		"corvette" -> StarshipType.GUNSHIP
 		"frigate" -> StarshipType.CORVETTE

--- a/src/main/kotlin/net/starlegacy/util/SignUtils.java
+++ b/src/main/kotlin/net/starlegacy/util/SignUtils.java
@@ -39,7 +39,7 @@ public class SignUtils {
         private String text;
 
         public String getText() {
-            return color == null ? text : ChatColor.valueOf(color.toUpperCase()) + text;
+            return color == null ? text : ChatColor.valueOf(color.uppercase()) + text;
         }
 
         public void setText(String text) {


### PR DESCRIPTION
Replaced all `toLowerCase` and `toUpperCase` with `lowercase` and `uppercase` (Deprecated since 1.5)